### PR TITLE
Add rapidyaml serializers/deserializers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # MoveIt Serialization
 
-Serializer for moveit_msgs. Currently supports yaml serialization through yaml-cpp.
+Serializer for moveit_msgs. Currently supports yaml serialization through yaml-cpp and rapidyaml.
 
 
 ## Roadmap
 - Add binary serealizer for ros_msgs
-- Change yaml-cpp to rapid-yaml [*EPIC*]
+- Deprecate yaml-cpp in favor of rapidyaml
+
+## rapidyaml
+**Alpha State**
+One of the fastest yaml parser and emiter available.
+
+ROS Dependency: https://github.com/captain-yoshi/ryml
+
 
 ## yaml-cpp
 
@@ -17,4 +24,4 @@ RViz depends on the `yaml-cpp` library. The [MoveIt Benchmark Suite](https://git
 
 ## Contribution
 
-The yaml conversion for decoding/encoding moveit_msgs was done by Zachary Kingston and taken from the [robowflex](https://github.com/KavrakiLab/robowflex) project.
+The yaml-cpp conversion for decoding/encoding moveit_msgs was done by Zachary Kingston and taken from the [robowflex](https://github.com/KavrakiLab/robowflex) project.

--- a/serialization/CMakeLists.txt
+++ b/serialization/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
 	moveit_core
 	moveit_msgs
 	moveit_serialization_yamlcpp
+	ryml
 )
 
 catkin_package(
@@ -21,6 +22,7 @@ catkin_package(
 	    moveit_core
 		moveit_msgs
 	    moveit_serialization_yamlcpp
+		ryml
 	DEPENDS
 	    Boost
 		EIGEN3

--- a/serialization/CMakeLists.txt
+++ b/serialization/CMakeLists.txt
@@ -47,7 +47,80 @@ add_library(${PROJECT_NAME}
 	src/yaml-cpp/conversion/trajectory_msgs.cpp
 	src/yaml-cpp/conversion/collision_detection.cpp
 	src/yaml-cpp/conversion/object_recognition_msgs.cpp
-	src/yaml-cpp/conversion/moveit_msgs.cpp)
+	src/yaml-cpp/conversion/moveit_msgs.cpp
+
+	# ros
+	src/ryml/ros/duration.cpp
+	src/ryml/ros/time.cpp
+
+	# std_msgs
+	src/ryml/std_msgs/color_rgba.cpp
+	src/ryml/std_msgs/header.cpp
+
+	# geometry_msgs
+	src/ryml/geometry_msgs/accel.cpp
+	src/ryml/geometry_msgs/vector3.cpp
+	src/ryml/geometry_msgs/point.cpp
+	src/ryml/geometry_msgs/quaternion.cpp
+	src/ryml/geometry_msgs/pose.cpp
+	src/ryml/geometry_msgs/transform.cpp
+	src/ryml/geometry_msgs/twist.cpp
+	src/ryml/geometry_msgs/wrench.cpp
+	src/ryml/geometry_msgs/pose_stamped.cpp
+	src/ryml/geometry_msgs/transform_stamped.cpp
+
+	# sensor_msgs
+	src/ryml/sensor_msgs/joint_state.cpp
+	src/ryml/sensor_msgs/multidof_joint_state.cpp
+
+	# shape_msgs
+	src/ryml/shape_msgs/mesh.cpp
+	src/ryml/shape_msgs/mesh_triangle.cpp
+	src/ryml/shape_msgs/plane.cpp
+	src/ryml/shape_msgs/solid_primitive.cpp
+
+	# object_recognition_msgs
+	src/ryml/object_recognition_msgs/object_type.cpp
+
+	# octomap_msgs
+	src/ryml/octomap_msgs/octomap.cpp
+	src/ryml/octomap_msgs/octomap_with_pose.cpp
+
+	# trajectory_msgs
+	src/ryml/trajectory_msgs/joint_trajectory.cpp
+	src/ryml/trajectory_msgs/joint_trajectory_point.cpp
+	src/ryml/trajectory_msgs/multidof_joint_trajectory.cpp
+	src/ryml/trajectory_msgs/multidof_joint_trajectory_point.cpp
+
+	# moveit_msgs
+    src/ryml/moveit_msgs/allowed_collision_entry.cpp
+    src/ryml/moveit_msgs/allowed_collision_matrix.cpp
+    src/ryml/moveit_msgs/attached_collision_object.cpp
+    src/ryml/moveit_msgs/bounding_volume.cpp
+    src/ryml/moveit_msgs/cartesian_point.cpp
+    src/ryml/moveit_msgs/cartesian_trajectory.cpp
+    src/ryml/moveit_msgs/cartesian_trajectory_point.cpp
+    src/ryml/moveit_msgs/collision_object.cpp
+    src/ryml/moveit_msgs/constraints.cpp
+    src/ryml/moveit_msgs/generic_trajectory.cpp
+    src/ryml/moveit_msgs/joint_constraint.cpp
+    src/ryml/moveit_msgs/link_padding.cpp
+    src/ryml/moveit_msgs/link_scale.cpp
+    src/ryml/moveit_msgs/motion_plan_request.cpp
+    src/ryml/moveit_msgs/object_color.cpp
+    src/ryml/moveit_msgs/orientation_constraint.cpp
+    src/ryml/moveit_msgs/planning_scene.cpp
+    src/ryml/moveit_msgs/planning_scene_world.cpp
+    src/ryml/moveit_msgs/position_constraint.cpp
+    src/ryml/moveit_msgs/robot_state.cpp
+    src/ryml/moveit_msgs/robot_trajectory.cpp
+    src/ryml/moveit_msgs/trajectory_constraints.cpp
+    src/ryml/moveit_msgs/visibility_constraint.cpp
+    src/ryml/moveit_msgs/workspace_parameters.cpp
+
+	# moveit
+	src/ryml/moveit/collision_detection/collision_request.cpp
+	)
 
 add_executable(run_example src/example.cpp)
 target_link_libraries(run_example ${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})

--- a/serialization/CMakeLists.txt
+++ b/serialization/CMakeLists.txt
@@ -49,6 +49,9 @@ add_library(${PROJECT_NAME}
 	src/yaml-cpp/conversion/object_recognition_msgs.cpp
 	src/yaml-cpp/conversion/moveit_msgs.cpp
 
+
+    src/ryml/error_handler.cpp
+
 	# ros
 	src/ryml/ros/duration.cpp
 	src/ryml/ros/time.cpp

--- a/serialization/include/moveit_serialization/ryml/error_handler.h
+++ b/serialization/include/moveit_serialization/ryml/error_handler.h
@@ -1,0 +1,79 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: Custom exception and error handler for ryml
+*/
+
+#pragma once
+
+#include <stdexcept>
+#include <c4/format.hpp>
+#include <ryml.hpp>
+
+namespace moveit_serialization {
+
+/// custom ryml runtime_error exception
+class yaml_error : public std::runtime_error
+{
+public:
+    explicit yaml_error(const std::string& what_arg) : runtime_error(what_arg){};
+    explicit yaml_error(const char* what_arg) : runtime_error(what_arg){};
+};
+
+struct ErrorHandler
+{
+    // this will be called on error
+    void on_error(const char* msg, size_t len, ryml::Location loc)
+    {
+        throw yaml_error(ryml::formatrs<std::string>("{}:{}:{} ({}B): ERROR: {}", loc.name, loc.line, loc.col,
+                                                     loc.offset, ryml::csubstr(msg, len)));
+    }
+
+    // bridge
+    ryml::Callbacks callbacks()
+    {
+        return ryml::Callbacks(this, nullptr, nullptr, ErrorHandler::s_error);
+    }
+    static void s_error(const char* msg, size_t len, ryml::Location loc, void* this_)
+    {
+        return ((ErrorHandler*)this_)->on_error(msg, len, loc);
+    }
+
+    ErrorHandler() : defaults(ryml::get_callbacks())
+    {}
+    ryml::Callbacks defaults;
+};
+
+}  // namespace moveit_serialization

--- a/serialization/include/moveit_serialization/ryml/format.h
+++ b/serialization/include/moveit_serialization/ryml/format.h
@@ -1,0 +1,79 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: Wrapper alternatives to format float types
+*/
+
+#pragma once
+
+#include <c4/format.hpp>
+
+namespace c4 {
+namespace yml {
+
+constexpr int GLOBAL_FLOAT_PRECISION = -1;
+
+// Create new float type
+template <class T>
+struct floattype
+{
+    T val;
+};
+
+// Convert float or double to floattype
+template <class T>
+inline auto freal(const T& t);
+
+template <>
+inline auto freal(const float& f)
+{
+    return floattype<float>{ f };
+}
+
+template <>
+inline auto freal(const double& d)
+{
+    return floattype<double>{ d };
+}
+
+// Wrapper for formating float and doubles
+template <class T>
+inline std::size_t to_chars(substr buf, floattype<T> fmt)
+{
+    return c4::ftoa(buf, fmt.val, GLOBAL_FLOAT_PRECISION, FTOA_FLOAT /*pick the proper format*/);
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/accel.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/accel.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/Accel.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Accel const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Accel* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/point.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/point.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/Point.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Point const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Point* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/pose.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/pose.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/Pose.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Pose const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Pose* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/pose_stamped.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/pose_stamped.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/PoseStamped.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::PoseStamped const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::PoseStamped* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/quaternion.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/quaternion.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/Quaternion.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Quaternion const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Quaternion* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/transform.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/transform.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/Transform.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Transform const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Transform* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/transform_stamped.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/transform_stamped.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/TransformStamped.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::TransformStamped const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::TransformStamped* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/twist.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/twist.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/Twist.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Twist const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Twist* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/vector3.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/vector3.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/Vector3.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Vector3 const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Vector3* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/geometry_msgs/wrench.h
+++ b/serialization/include/moveit_serialization/ryml/geometry_msgs/wrench.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <geometry_msgs/Wrench.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Wrench const& rhs);
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Wrench* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit/collision_detection/collision_request.h
+++ b/serialization/include/moveit_serialization/ryml/moveit/collision_detection/collision_request.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer for collision_detection
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit/collision_detection/collision_common.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, collision_detection::CollisionRequest const& rhs);
+bool read(c4::yml::NodeRef const& n, collision_detection::CollisionRequest* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/allowed_collision_entry.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/allowed_collision_entry.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/AllowedCollisionEntry.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::AllowedCollisionEntry const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::AllowedCollisionEntry* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/allowed_collision_matrix.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/allowed_collision_matrix.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/AllowedCollisionMatrix.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::AllowedCollisionMatrix const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::AllowedCollisionMatrix* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/attached_collision_object.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/attached_collision_object.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/AttachedCollisionObject.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::AttachedCollisionObject const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::AttachedCollisionObject* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/bounding_volume.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/bounding_volume.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/BoundingVolume.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::BoundingVolume const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::BoundingVolume* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/cartesian_point.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/cartesian_point.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/CartesianPoint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::CartesianPoint const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::CartesianPoint* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/cartesian_trajectory.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/cartesian_trajectory.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/CartesianTrajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::CartesianTrajectory const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::CartesianTrajectory* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/cartesian_trajectory_point.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/cartesian_trajectory_point.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/CartesianTrajectoryPoint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::CartesianTrajectoryPoint const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::CartesianTrajectoryPoint* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/collision_object.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/collision_object.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/CollisionObject.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::CollisionObject const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::CollisionObject* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/constraints.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/constraints.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/Constraints.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::Constraints const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::Constraints* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/generic_trajectory.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/generic_trajectory.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/GenericTrajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::GenericTrajectory const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::GenericTrajectory* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/joint_constraint.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/joint_constraint.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/JointConstraint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::JointConstraint const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::JointConstraint* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/link_padding.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/link_padding.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/LinkPadding.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::LinkPadding const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::LinkPadding* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/link_scale.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/link_scale.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/LinkScale.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::LinkScale const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::LinkScale* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/motion_plan_request.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/motion_plan_request.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/MotionPlanRequest.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::MotionPlanRequest const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::MotionPlanRequest* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/object_color.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/object_color.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/ObjectColor.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::ObjectColor const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::ObjectColor* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/orientation_constraint.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/orientation_constraint.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/OrientationConstraint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::OrientationConstraint const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::OrientationConstraint* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/planning_scene.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/planning_scene.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/PlanningScene.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::PlanningScene const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::PlanningScene* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/planning_scene_world.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/planning_scene_world.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/PlanningSceneWorld.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::PlanningSceneWorld const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::PlanningSceneWorld* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/position_constraint.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/position_constraint.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/PositionConstraint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::PositionConstraint const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::PositionConstraint* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/robot_state.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/robot_state.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/RobotState.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::RobotState const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::RobotState* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/robot_trajectory.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/robot_trajectory.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/RobotTrajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::RobotTrajectory const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::RobotTrajectory* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/trajectory_constraints.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/trajectory_constraints.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/TrajectoryConstraints.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::TrajectoryConstraints const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::TrajectoryConstraints* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/visibility_constraint.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/visibility_constraint.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/VisibilityConstraint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::VisibilityConstraint const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::VisibilityConstraint* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/moveit_msgs/workspace_parameters.h
+++ b/serialization/include/moveit_serialization/ryml/moveit_msgs/workspace_parameters.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <moveit_msgs/WorkspaceParameters.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::WorkspaceParameters const& rhs);
+bool read(c4::yml::NodeRef const& n, moveit_msgs::WorkspaceParameters* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/object_recognition_msgs/object_type.h
+++ b/serialization/include/moveit_serialization/ryml/object_recognition_msgs/object_type.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <object_recognition_msgs/ObjectType.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, object_recognition_msgs::ObjectType const& rhs);
+bool read(c4::yml::NodeRef const& n, object_recognition_msgs::ObjectType* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/octomap_msgs/octomap.h
+++ b/serialization/include/moveit_serialization/ryml/octomap_msgs/octomap.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <octomap_msgs/Octomap.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, octomap_msgs::Octomap const& rhs);
+bool read(c4::yml::NodeRef const& n, octomap_msgs::Octomap* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/octomap_msgs/octomap_with_pose.h
+++ b/serialization/include/moveit_serialization/ryml/octomap_msgs/octomap_with_pose.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <octomap_msgs/OctomapWithPose.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, octomap_msgs::OctomapWithPose const& rhs);
+bool read(c4::yml::NodeRef const& n, octomap_msgs::OctomapWithPose* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/ros/duration.h
+++ b/serialization/include/moveit_serialization/ryml/ros/duration.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer for ros
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <ros/time.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, ros::Duration const& rhs);
+bool read(c4::yml::NodeRef const& n, ros::Duration* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/ros/time.h
+++ b/serialization/include/moveit_serialization/ryml/ros/time.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer for ros
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <ros/time.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, ros::Time const& rhs);
+bool read(c4::yml::NodeRef const& n, ros::Time* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/ryml.h
+++ b/serialization/include/moveit_serialization/ryml/ryml.h
@@ -39,7 +39,7 @@
 #pragma once
 
 // std (map, vector, string)
-#include <ryml_std.hpp>
+#include <moveit_serialization/ryml/std.h>
 
 // ros
 #include <moveit_serialization/ryml/ros/duration.h>
@@ -113,8 +113,13 @@
 // moveit
 #include <moveit_serialization/ryml/moveit/collision_detection/collision_request.h>
 
+// formatters
+#include <moveit_serialization/ryml/format.h>
+
 // WARNING: Do NOT include headers below this line
 // Please take note of the following pitfall when using serialization
 // functions: you have to include the header with the serialization
 // before any other headers that use functions from it.
+#include <moveit_serialization/ryml/error_handler.h>  // includes ryml.hpp in the header
+
 #include <ryml.hpp>

--- a/serialization/include/moveit_serialization/ryml/ryml.h
+++ b/serialization/include/moveit_serialization/ryml/ryml.h
@@ -1,0 +1,120 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: Contains all conversion headers
+*/
+
+#pragma once
+
+// std (map, vector, string)
+#include <ryml_std.hpp>
+
+// ros
+#include <moveit_serialization/ryml/ros/duration.h>
+#include <moveit_serialization/ryml/ros/time.h>
+
+// std_msgs
+#include <moveit_serialization/ryml/std_msgs/color_rgba.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+
+// geometry_msgs
+#include <moveit_serialization/ryml/geometry_msgs/accel.h>
+#include <moveit_serialization/ryml/geometry_msgs/point.h>
+#include <moveit_serialization/ryml/geometry_msgs/quaternion.h>
+#include <moveit_serialization/ryml/geometry_msgs/vector3.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose_stamped.h>
+#include <moveit_serialization/ryml/geometry_msgs/transform.h>
+#include <moveit_serialization/ryml/geometry_msgs/transform_stamped.h>
+#include <moveit_serialization/ryml/geometry_msgs/twist.h>
+#include <moveit_serialization/ryml/geometry_msgs/wrench.h>
+
+// sensor_msgs
+#include <moveit_serialization/ryml/sensor_msgs/joint_state.h>
+#include <moveit_serialization/ryml/sensor_msgs/multidof_joint_state.h>
+
+// shape_msgs
+#include <moveit_serialization/ryml/shape_msgs/mesh.h>
+#include <moveit_serialization/ryml/shape_msgs/mesh_triangle.h>
+#include <moveit_serialization/ryml/shape_msgs/plane.h>
+#include <moveit_serialization/ryml/shape_msgs/solid_primitive.h>
+
+// object_recognition_msgs
+#include <moveit_serialization/ryml/object_recognition_msgs/object_type.h>
+
+// octomap_msgs
+#include <moveit_serialization/ryml/octomap_msgs/octomap.h>
+#include <moveit_serialization/ryml/octomap_msgs/octomap_with_pose.h>
+
+// trajectory_msgs
+#include <moveit_serialization/ryml/trajectory_msgs/joint_trajectory_point.h>
+#include <moveit_serialization/ryml/trajectory_msgs/joint_trajectory.h>
+#include <moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory_point.h>
+#include <moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory.h>
+
+// moveit_msgs
+#include <moveit_serialization/ryml/moveit_msgs/allowed_collision_entry.h>
+#include <moveit_serialization/ryml/moveit_msgs/allowed_collision_matrix.h>
+#include <moveit_serialization/ryml/moveit_msgs/attached_collision_object.h>
+#include <moveit_serialization/ryml/moveit_msgs/bounding_volume.h>
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_point.h>
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_trajectory.h>
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_trajectory_point.h>
+#include <moveit_serialization/ryml/moveit_msgs/collision_object.h>
+#include <moveit_serialization/ryml/moveit_msgs/constraints.h>
+#include <moveit_serialization/ryml/moveit_msgs/generic_trajectory.h>
+#include <moveit_serialization/ryml/moveit_msgs/joint_constraint.h>
+#include <moveit_serialization/ryml/moveit_msgs/link_padding.h>
+#include <moveit_serialization/ryml/moveit_msgs/link_scale.h>
+#include <moveit_serialization/ryml/moveit_msgs/motion_plan_request.h>
+#include <moveit_serialization/ryml/moveit_msgs/object_color.h>
+#include <moveit_serialization/ryml/moveit_msgs/orientation_constraint.h>
+#include <moveit_serialization/ryml/moveit_msgs/planning_scene.h>
+#include <moveit_serialization/ryml/moveit_msgs/planning_scene_world.h>
+#include <moveit_serialization/ryml/moveit_msgs/position_constraint.h>
+#include <moveit_serialization/ryml/moveit_msgs/robot_state.h>
+#include <moveit_serialization/ryml/moveit_msgs/robot_trajectory.h>
+#include <moveit_serialization/ryml/moveit_msgs/trajectory_constraints.h>
+#include <moveit_serialization/ryml/moveit_msgs/visibility_constraint.h>
+#include <moveit_serialization/ryml/moveit_msgs/workspace_parameters.h>
+
+// moveit
+#include <moveit_serialization/ryml/moveit/collision_detection/collision_request.h>
+
+// WARNING: Do NOT include headers below this line
+// Please take note of the following pitfall when using serialization
+// functions: you have to include the header with the serialization
+// before any other headers that use functions from it.
+#include <ryml.hpp>

--- a/serialization/include/moveit_serialization/ryml/sensor_msgs/joint_state.h
+++ b/serialization/include/moveit_serialization/ryml/sensor_msgs/joint_state.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <sensor_msgs/JointState.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, sensor_msgs::JointState const& rhs);
+bool read(c4::yml::NodeRef const& n, sensor_msgs::JointState* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/sensor_msgs/multidof_joint_state.h
+++ b/serialization/include/moveit_serialization/ryml/sensor_msgs/multidof_joint_state.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <sensor_msgs/MultiDOFJointState.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, sensor_msgs::MultiDOFJointState const& rhs);
+bool read(c4::yml::NodeRef const& n, sensor_msgs::MultiDOFJointState* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/shape_msgs/mesh.h
+++ b/serialization/include/moveit_serialization/ryml/shape_msgs/mesh.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <shape_msgs/Mesh.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, shape_msgs::Mesh const& rhs);
+bool read(c4::yml::NodeRef const& n, shape_msgs::Mesh* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/shape_msgs/mesh_triangle.h
+++ b/serialization/include/moveit_serialization/ryml/shape_msgs/mesh_triangle.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer for ros
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <shape_msgs/MeshTriangle.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, shape_msgs::MeshTriangle const& rhs);
+bool read(c4::yml::NodeRef const& n, shape_msgs::MeshTriangle* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/shape_msgs/plane.h
+++ b/serialization/include/moveit_serialization/ryml/shape_msgs/plane.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer for ros
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <shape_msgs/Plane.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, shape_msgs::Plane const& rhs);
+bool read(c4::yml::NodeRef const& n, shape_msgs::Plane* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/shape_msgs/solid_primitive.h
+++ b/serialization/include/moveit_serialization/ryml/shape_msgs/solid_primitive.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer for ros
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <shape_msgs/SolidPrimitive.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, shape_msgs::SolidPrimitive const& rhs);
+bool read(c4::yml::NodeRef const& n, shape_msgs::SolidPrimitive* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/std.h
+++ b/serialization/include/moveit_serialization/ryml/std.h
@@ -1,0 +1,162 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: Default std header to force formating on floats
+*/
+
+#pragma once
+
+#include <c4/yml/std/std.hpp>
+#include <moveit_serialization/ryml/format.h>
+
+namespace c4 {
+namespace yml {
+
+// specialize vector of floats
+template <class Alloc>
+void write(c4::yml::NodeRef* n, std::vector<float, Alloc> const& vec)
+{
+    *n |= c4::yml::SEQ;
+    for (auto const& v : vec) {
+        n->append_child() << freal(v);
+    }
+}
+
+template <class Alloc>
+void write(c4::yml::NodeRef* n, std::vector<double, Alloc> const& vec)
+{
+    *n |= c4::yml::SEQ;
+    for (auto const& v : vec) {
+        n->append_child() << freal(v);
+    }
+}
+
+// specialize map of floats (3^3 - 1 possibilities)
+template <class V, class Less, class Alloc>
+void write(c4::yml::NodeRef* n, std::map<float, V, Less, Alloc> const& m)
+{
+    *n |= c4::yml::MAP;
+    for (auto const& p : m) {
+        auto ch = n->append_child();
+        auto r = freal(p.first);
+        ch << c4::yml::key(r);
+        ch << p.second;
+    }
+}
+
+template <class Less, class Alloc>
+void write(c4::yml::NodeRef* n, std::map<float, float, Less, Alloc> const& m)
+{
+    *n |= c4::yml::MAP;
+    for (auto const& p : m) {
+        auto ch = n->append_child();
+        auto r = freal(p.first);
+        ch << c4::yml::key(r);
+        ch << freal(p.second);
+    }
+}
+
+template <class Less, class Alloc>
+void write(c4::yml::NodeRef* n, std::map<float, double, Less, Alloc> const& m)
+{
+    *n |= c4::yml::MAP;
+    for (auto const& p : m) {
+        auto ch = n->append_child();
+        auto r = freal(p.first);
+        ch << c4::yml::key(r);
+        ch << freal(p.second);
+    }
+}
+
+template <class K, class Less, class Alloc>
+void write(c4::yml::NodeRef* n, std::map<K, float, Less, Alloc> const& m)
+{
+    *n |= c4::yml::MAP;
+    for (auto const& p : m) {
+        auto ch = n->append_child();
+        ch << c4::yml::key(p.first);
+        ch << freal(p.second);
+    }
+}
+
+template <class V, class Less, class Alloc>
+void write(c4::yml::NodeRef* n, std::map<double, V, Less, Alloc> const& m)
+{
+    *n |= c4::yml::MAP;
+    for (auto const& p : m) {
+        auto ch = n->append_child();
+        auto r = freal(p.first);
+        ch << c4::yml::key(r);
+        ch << p.second;
+    }
+}
+
+template <class Less, class Alloc>
+void write(c4::yml::NodeRef* n, std::map<double, double, Less, Alloc> const& m)
+{
+    *n |= c4::yml::MAP;
+    for (auto const& p : m) {
+        auto ch = n->append_child();
+        auto r = freal(p.first);
+        ch << c4::yml::key(r);
+        ch << freal(p.second);
+    }
+}
+
+template <class Less, class Alloc>
+void write(c4::yml::NodeRef* n, std::map<double, float, Less, Alloc> const& m)
+{
+    *n |= c4::yml::MAP;
+    for (auto const& p : m) {
+        auto ch = n->append_child();
+        auto r = freal(p.first);
+        ch << c4::yml::key(r);
+        ch << freal(p.second);
+    }
+}
+
+template <class K, class Less, class Alloc>
+void write(c4::yml::NodeRef* n, std::map<K, double, Less, Alloc> const& m)
+{
+    *n |= c4::yml::MAP;
+    for (auto const& p : m) {
+        auto ch = n->append_child();
+        ch << c4::yml::key(p.first);
+        ch << freal(p.second);
+    }
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/std_msgs/color_rgba.h
+++ b/serialization/include/moveit_serialization/ryml/std_msgs/color_rgba.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer for ros
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <std_msgs/ColorRGBA.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, std_msgs::ColorRGBA const& rhs);
+bool read(c4::yml::NodeRef const& n, std_msgs::ColorRGBA* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/std_msgs/header.h
+++ b/serialization/include/moveit_serialization/ryml/std_msgs/header.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer for std_msgs::Header
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <std_msgs/Header.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, std_msgs::Header const& rhs);
+bool read(c4::yml::NodeRef const& n, std_msgs::Header* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/trajectory_msgs/joint_trajectory.h
+++ b/serialization/include/moveit_serialization/ryml/trajectory_msgs/joint_trajectory.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <trajectory_msgs/JointTrajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, trajectory_msgs::JointTrajectory const& rhs);
+bool read(c4::yml::NodeRef const& n, trajectory_msgs::JointTrajectory* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/trajectory_msgs/joint_trajectory_point.h
+++ b/serialization/include/moveit_serialization/ryml/trajectory_msgs/joint_trajectory_point.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <trajectory_msgs/JointTrajectoryPoint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, trajectory_msgs::JointTrajectoryPoint const& rhs);
+bool read(c4::yml::NodeRef const& n, trajectory_msgs::JointTrajectoryPoint* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory.h
+++ b/serialization/include/moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <trajectory_msgs/MultiDOFJointTrajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, trajectory_msgs::MultiDOFJointTrajectory const& rhs);
+bool read(c4::yml::NodeRef const& n, trajectory_msgs::MultiDOFJointTrajectory* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/include/moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory_point.h
+++ b/serialization/include/moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory_point.h
@@ -1,0 +1,52 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2021, Captain Yoshi
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Captain Yoshi
+   Desc: YAML serializer/deserializer
+*/
+
+#pragma once
+
+#include <c4/yml/node.hpp>
+
+#include <trajectory_msgs/MultiDOFJointTrajectoryPoint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, trajectory_msgs::MultiDOFJointTrajectoryPoint const& rhs);
+bool read(c4::yml::NodeRef const& n, trajectory_msgs::MultiDOFJointTrajectoryPoint* rhs);
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/package.xml
+++ b/serialization/package.xml
@@ -14,4 +14,5 @@
 	<depend>moveit_core</depend>
 	<depend>moveit_msgs</depend>
 	<depend>moveit_serialization_yamlcpp</depend>
+	<depend>ryml</depend>
 </package>

--- a/serialization/src/ryml/error_handler.cpp
+++ b/serialization/src/ryml/error_handler.cpp
@@ -1,0 +1,20 @@
+#include <moveit_serialization/ryml/error_handler.h>
+
+namespace moveit_serialization {
+
+// https://pabloariasal.github.io/2020/01/02/static-variable-initialization/#solving-the-static-initialization-order-fiasco
+auto& registerErrorHandler()
+{
+    static auto err = ErrorHandler();
+    c4::yml::set_callbacks(err.callbacks());
+
+    return err;
+}
+
+namespace {
+
+auto ERROR_HANDLER = registerErrorHandler();
+
+}  // namespace
+
+}  // namespace moveit_serialization

--- a/serialization/src/ryml/geometry_msgs/accel.cpp
+++ b/serialization/src/ryml/geometry_msgs/accel.cpp
@@ -1,0 +1,27 @@
+#include <moveit_serialization/ryml/geometry_msgs/vector3.h>
+
+#include <moveit_serialization/ryml/geometry_msgs/accel.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Accel const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("linear") << rhs.linear;
+    n->append_child() << yml::key("angular") << rhs.angular;
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Accel* rhs)
+{
+    if (n.has_child("linear"))
+        n["linear"] >> rhs->linear;
+    if (n.has_child("angular"))
+        n["angular"] >> rhs->angular;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/point.cpp
+++ b/serialization/src/ryml/geometry_msgs/point.cpp
@@ -1,0 +1,26 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/geometry_msgs/point.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Point const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("x") << freal(rhs.x);
+    n->append_child() << yml::key("y") << freal(rhs.y);
+    n->append_child() << yml::key("z") << freal(rhs.z);
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Point* rhs)
+{
+    n["x"] >> rhs->x;
+    n["y"] >> rhs->y;
+    n["z"] >> rhs->z;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/pose.cpp
+++ b/serialization/src/ryml/geometry_msgs/pose.cpp
@@ -1,0 +1,25 @@
+#include <moveit_serialization/ryml/geometry_msgs/point.h>
+#include <moveit_serialization/ryml/geometry_msgs/quaternion.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Pose const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("position") << rhs.position;
+    n->append_child() << yml::key("orientation") << rhs.orientation;
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Pose* rhs)
+{
+    n["position"] >> rhs->position;
+    n["orientation"] >> rhs->position;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/pose_stamped.cpp
+++ b/serialization/src/ryml/geometry_msgs/pose_stamped.cpp
@@ -1,0 +1,25 @@
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose_stamped.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::PoseStamped const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("pose") << rhs.pose;
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::PoseStamped* rhs)
+{
+    n["header"] >> rhs->header;
+    n["pose"] >> rhs->pose;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/quaternion.cpp
+++ b/serialization/src/ryml/geometry_msgs/quaternion.cpp
@@ -1,0 +1,28 @@
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/geometry_msgs/quaternion.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Quaternion const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("x") << freal(rhs.x);
+    n->append_child() << yml::key("y") << freal(rhs.y);
+    n->append_child() << yml::key("z") << freal(rhs.z);
+    n->append_child() << yml::key("w") << freal(rhs.w);
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Quaternion* rhs)
+{
+    n["x"] >> rhs->x;
+    n["y"] >> rhs->y;
+    n["z"] >> rhs->z;
+    n["w"] >> rhs->w;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/transform.cpp
+++ b/serialization/src/ryml/geometry_msgs/transform.cpp
@@ -1,0 +1,25 @@
+#include <moveit_serialization/ryml/geometry_msgs/vector3.h>
+#include <moveit_serialization/ryml/geometry_msgs/quaternion.h>
+#include <moveit_serialization/ryml/geometry_msgs/transform.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Transform const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("translation") << rhs.translation;
+    n->append_child() << yml::key("rotation") << rhs.rotation;
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Transform* rhs)
+{
+    n["translation"] >> rhs->translation;
+    n["rotation"] >> rhs->rotation;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/transform_stamped.cpp
+++ b/serialization/src/ryml/geometry_msgs/transform_stamped.cpp
@@ -1,0 +1,29 @@
+#include <moveit_serialization/ryml/std.h>
+
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/geometry_msgs/transform.h>
+#include <moveit_serialization/ryml/geometry_msgs/transform_stamped.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::TransformStamped const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("child_frame_id") << rhs.child_frame_id;
+    n->append_child() << yml::key("transform") << rhs.transform;
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::TransformStamped* rhs)
+{
+    n["header"] >> rhs->header;
+    n["child_frame_id"] >> rhs->child_frame_id;
+    n["transform"] >> rhs->transform;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/twist.cpp
+++ b/serialization/src/ryml/geometry_msgs/twist.cpp
@@ -1,0 +1,24 @@
+#include <moveit_serialization/ryml/geometry_msgs/vector3.h>
+#include <moveit_serialization/ryml/geometry_msgs/twist.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Twist const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("linear") << rhs.linear;
+    n->append_child() << yml::key("angular") << rhs.angular;
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Twist* rhs)
+{
+    n["linear"] >> rhs->linear;
+    n["angular"] >> rhs->angular;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/vector3.cpp
+++ b/serialization/src/ryml/geometry_msgs/vector3.cpp
@@ -1,0 +1,26 @@
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/geometry_msgs/vector3.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Vector3 const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("x") << freal(rhs.x);
+    n->append_child() << yml::key("y") << freal(rhs.y);
+    n->append_child() << yml::key("z") << freal(rhs.z);
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Vector3* rhs)
+{
+    n["x"] >> rhs->x;
+    n["y"] >> rhs->y;
+    n["z"] >> rhs->z;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/geometry_msgs/wrench.cpp
+++ b/serialization/src/ryml/geometry_msgs/wrench.cpp
@@ -1,0 +1,24 @@
+#include <moveit_serialization/ryml/geometry_msgs/vector3.h>
+#include <moveit_serialization/ryml/geometry_msgs/wrench.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, geometry_msgs::Wrench const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("force") << rhs.force;
+    n->append_child() << yml::key("torque") << rhs.torque;
+}
+
+bool read(c4::yml::NodeRef const& n, geometry_msgs::Wrench* rhs)
+{
+    n["force"] >> rhs->force;
+    n["torque"] >> rhs->torque;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit/collision_detection/collision_request.cpp
+++ b/serialization/src/ryml/moveit/collision_detection/collision_request.cpp
@@ -1,0 +1,48 @@
+#include <moveit_serialization/ryml/std.h>
+
+#include <moveit_serialization/ryml/moveit/collision_detection/collision_request.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, collision_detection::CollisionRequest const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    // Faster using the index API ~125% faster the the node API
+    // See: https://github.com/biojppm/rapidyaml/issues/242
+    // Tree* t = n->tree();
+    // t->to_keyval(t->append_child(0), "distance", t->to_arena(rhs.distance));
+    // t->to_keyval(t->append_child(0), "cost", t->to_arena(rhs.cost));
+    // t->to_keyval(t->append_child(0), "contacts", t->to_arena(rhs.contacts));
+    // t->to_keyval(t->append_child(0), "max_contacts", t->to_arena(rhs.max_contacts));
+    // t->to_keyval(t->append_child(0), "max_contacts_per_pair", t->to_arena(rhs.max_contacts_per_pair));
+    // t->to_keyval(t->append_child(0), "max_cost_sources", t->to_arena(rhs.max_cost_sources));
+    // t->to_keyval(t->append_child(0), "verbose", t->to_arena(rhs.verbose));
+    // t->to_keyval(t->append_child(0), "group_name", t->to_arena(rhs.group_name));
+
+    n->append_child() << yml::key("distance") << rhs.distance;
+    n->append_child() << yml::key("cost") << rhs.cost;
+    n->append_child() << yml::key("contacts") << rhs.contacts;
+    n->append_child() << yml::key("max_contacts") << rhs.max_contacts;
+    n->append_child() << yml::key("max_contacts_per_pair") << rhs.max_contacts_per_pair;
+    n->append_child() << yml::key("max_cost_sources") << rhs.max_cost_sources;
+    n->append_child() << yml::key("verbose") << rhs.verbose;
+    n->append_child() << yml::key("group_name") << rhs.group_name;
+}
+
+bool read(c4::yml::NodeRef const& n, collision_detection::CollisionRequest* rhs)
+{
+    n["distance"] >> rhs->distance;
+    n["cost"] >> rhs->cost;
+    n["contacts"] >> rhs->contacts;
+    n["max_contacts"] >> rhs->max_contacts;
+    n["max_contacts_per_pair"] >> rhs->max_contacts_per_pair;
+    n["max_cost_sources"] >> rhs->max_cost_sources;
+    n["verbose"] >> rhs->verbose;
+    n["group_name"] >> rhs->group_name;
+
+    return true;
+}
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/allowed_collision_entry.cpp
+++ b/serialization/src/ryml/moveit_msgs/allowed_collision_entry.cpp
@@ -1,0 +1,24 @@
+#include <moveit_serialization/ryml/std.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/allowed_collision_entry.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::AllowedCollisionEntry const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("enabled") << rhs.enabled;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::AllowedCollisionEntry* rhs)
+{
+    if (n.has_child("enabled"))
+        n["enabled"] >> rhs->enabled;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/allowed_collision_matrix.cpp
+++ b/serialization/src/ryml/moveit_msgs/allowed_collision_matrix.cpp
@@ -1,0 +1,34 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/moveit_msgs/allowed_collision_entry.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/allowed_collision_matrix.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::AllowedCollisionMatrix const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("entry_names") << rhs.entry_names;
+    n->append_child() << yml::key("entry_values") << rhs.entry_values;
+    n->append_child() << yml::key("default_entry_names") << rhs.default_entry_names;
+    n->append_child() << yml::key("default_entry_values") << rhs.default_entry_values;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::AllowedCollisionMatrix* rhs)
+{
+    if (n.has_child("entry_names"))
+        n["entry_names"] >> rhs->entry_names;
+    if (n.has_child("entry_values"))
+        n["entry_values"] >> rhs->entry_values;
+    if (n.has_child("default_entry_names"))
+        n["default_entry_names"] >> rhs->default_entry_names;
+    if (n.has_child("default_entry_values"))
+        n["default_entry_values"] >> rhs->default_entry_values;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/attached_collision_object.cpp
+++ b/serialization/src/ryml/moveit_msgs/attached_collision_object.cpp
@@ -1,0 +1,38 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/moveit_msgs/collision_object.h>
+#include <moveit_serialization/ryml/trajectory_msgs/joint_trajectory.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/attached_collision_object.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::AttachedCollisionObject const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("link_name") << rhs.link_name;
+    n->append_child() << yml::key("object") << rhs.object;
+    n->append_child() << yml::key("touch_links") << rhs.touch_links;
+    n->append_child() << yml::key("detach_posture") << rhs.detach_posture;
+    n->append_child() << yml::key("weight") << freal(rhs.weight);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::AttachedCollisionObject* rhs)
+{
+    if (n.has_child("link_name"))
+        n["link_name"] >> rhs->link_name;
+    if (n.has_child("object"))
+        n["object"] >> rhs->object;
+    if (n.has_child("touch_links"))
+        n["touch_links"] >> rhs->touch_links;
+    if (n.has_child("detach_posture"))
+        n["detach_posture"] >> rhs->detach_posture;
+    if (n.has_child("weight"))
+        n["weight"] >> rhs->weight;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/bounding_volume.cpp
+++ b/serialization/src/ryml/moveit_msgs/bounding_volume.cpp
@@ -1,0 +1,36 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose.h>
+#include <moveit_serialization/ryml/shape_msgs/solid_primitive.h>
+#include <moveit_serialization/ryml/shape_msgs/mesh.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/bounding_volume.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::BoundingVolume const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("primitives") << rhs.primitives;
+    n->append_child() << yml::key("primitive_poses") << rhs.primitive_poses;
+    n->append_child() << yml::key("meshes") << rhs.meshes;
+    n->append_child() << yml::key("mesh_poses") << rhs.mesh_poses;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::BoundingVolume* rhs)
+{
+    if (n.has_child("primitives"))
+        n["primitives"] >> rhs->primitives;
+    if (n.has_child("primitive_poses"))
+        n["primitive_poses"] >> rhs->primitive_poses;
+    if (n.has_child("meshes"))
+        n["meshes"] >> rhs->meshes;
+    if (n.has_child("mesh_poses"))
+        n["mesh_poses"] >> rhs->mesh_poses;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/cartesian_point.cpp
+++ b/serialization/src/ryml/moveit_msgs/cartesian_point.cpp
@@ -1,0 +1,32 @@
+#include <moveit_serialization/ryml/geometry_msgs/pose.h>
+#include <moveit_serialization/ryml/geometry_msgs/twist.h>
+#include <moveit_serialization/ryml/geometry_msgs/accel.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_point.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::CartesianPoint const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("pose") << rhs.pose;
+    n->append_child() << yml::key("velocity") << rhs.velocity;
+    n->append_child() << yml::key("acceleration") << rhs.acceleration;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::CartesianPoint* rhs)
+{
+    if (n.has_child("pose"))
+        n["pose"] >> rhs->pose;
+    if (n.has_child("velocity"))
+        n["velocity"] >> rhs->velocity;
+    if (n.has_child("acceleration"))
+        n["acceleration"] >> rhs->acceleration;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/cartesian_trajectory.cpp
+++ b/serialization/src/ryml/moveit_msgs/cartesian_trajectory.cpp
@@ -1,0 +1,32 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_trajectory_point.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_trajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::CartesianTrajectory const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("tracked_frame") << rhs.tracked_frame;
+    n->append_child() << yml::key("points") << rhs.points;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::CartesianTrajectory* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("tracked_frame"))
+        n["tracked_frame"] >> rhs->tracked_frame;
+    if (n.has_child("points"))
+        n["points"] >> rhs->points;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/cartesian_trajectory_point.cpp
+++ b/serialization/src/ryml/moveit_msgs/cartesian_trajectory_point.cpp
@@ -1,0 +1,28 @@
+#include <moveit_serialization/ryml/ros/duration.h>
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_point.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_trajectory_point.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::CartesianTrajectoryPoint const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("point") << rhs.point;
+    n->append_child() << yml::key("time_from_start") << rhs.time_from_start;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::CartesianTrajectoryPoint* rhs)
+{
+    if (n.has_child("point"))
+        n["point"] >> rhs->point;
+    if (n.has_child("time_from_start"))
+        n["time_from_start"] >> rhs->time_from_start;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/collision_object.cpp
+++ b/serialization/src/ryml/moveit_msgs/collision_object.cpp
@@ -1,0 +1,66 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/object_recognition_msgs/object_type.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose.h>
+#include <moveit_serialization/ryml/shape_msgs/mesh.h>
+#include <moveit_serialization/ryml/shape_msgs/solid_primitive.h>
+#include <moveit_serialization/ryml/shape_msgs/plane.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/collision_object.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::CollisionObject const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("pose") << rhs.pose;
+    n->append_child() << yml::key("id") << rhs.id;
+    n->append_child() << yml::key("type") << rhs.type;
+    n->append_child() << yml::key("primitives") << rhs.primitives;
+    n->append_child() << yml::key("primitive_poses") << rhs.primitive_poses;
+    n->append_child() << yml::key("meshes") << rhs.meshes;
+    n->append_child() << yml::key("mesh_poses") << rhs.mesh_poses;
+    n->append_child() << yml::key("planes") << rhs.planes;
+    n->append_child() << yml::key("plane_poses") << rhs.plane_poses;
+    n->append_child() << yml::key("subframe_names") << rhs.subframe_names;
+    n->append_child() << yml::key("subframe_poses") << rhs.subframe_poses;
+    n->append_child() << yml::key("operation") << rhs.operation;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::CollisionObject* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("pose"))
+        n["pose"] >> rhs->pose;
+    if (n.has_child("id"))
+        n["id"] >> rhs->id;
+    if (n.has_child("type"))
+        n["type"] >> rhs->type;
+    if (n.has_child("primitives"))
+        n["primitives"] >> rhs->primitives;
+    if (n.has_child("primitive_poses"))
+        n["primitive_poses"] >> rhs->primitive_poses;
+    if (n.has_child("meshes"))
+        n["meshes"] >> rhs->meshes;
+    if (n.has_child("mesh_poses"))
+        n["mesh_poses"] >> rhs->mesh_poses;
+    if (n.has_child("planes"))
+        n["planes"] >> rhs->planes;
+    if (n.has_child("plane_poses"))
+        n["plane_poses"] >> rhs->plane_poses;
+    if (n.has_child("subframe_names"))
+        n["subframe_names"] >> rhs->subframe_names;
+    if (n.has_child("subframe_poses"))
+        n["subframe_poses"] >> rhs->subframe_poses;
+    if (n.has_child("operation"))
+        n["operation"] >> rhs->operation;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/constraints.cpp
+++ b/serialization/src/ryml/moveit_msgs/constraints.cpp
@@ -1,0 +1,40 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/moveit_msgs/joint_constraint.h>
+#include <moveit_serialization/ryml/moveit_msgs/position_constraint.h>
+#include <moveit_serialization/ryml/moveit_msgs/orientation_constraint.h>
+#include <moveit_serialization/ryml/moveit_msgs/visibility_constraint.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/constraints.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::Constraints const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("name") << rhs.name;
+    n->append_child() << yml::key("joint_constraints") << rhs.joint_constraints;
+    n->append_child() << yml::key("position_constraints") << rhs.position_constraints;
+    n->append_child() << yml::key("orientation_constraints") << rhs.orientation_constraints;
+    n->append_child() << yml::key("visibility_constraints") << rhs.visibility_constraints;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::Constraints* rhs)
+{
+    if (n.has_child("name"))
+        n["name"] >> rhs->name;
+    if (n.has_child("joint_constraints"))
+        n["joint_constraints"] >> rhs->joint_constraints;
+    if (n.has_child("position_constraints"))
+        n["position_constraints"] >> rhs->position_constraints;
+    if (n.has_child("orientation_constraints"))
+        n["orientation_constraints"] >> rhs->orientation_constraints;
+    if (n.has_child("visibility_constraints"))
+        n["visibility_constraints"] >> rhs->visibility_constraints;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/generic_trajectory.cpp
+++ b/serialization/src/ryml/moveit_msgs/generic_trajectory.cpp
@@ -1,0 +1,33 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/trajectory_msgs/joint_trajectory.h>
+#include <moveit_serialization/ryml/moveit_msgs/cartesian_trajectory.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/generic_trajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::GenericTrajectory const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("joint_trajectory") << rhs.joint_trajectory;
+    n->append_child() << yml::key("cartesian_trajectory") << rhs.cartesian_trajectory;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::GenericTrajectory* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("joint_trajectory"))
+        n["joint_trajectory"] >> rhs->joint_trajectory;
+    if (n.has_child("cartesian_trajectory"))
+        n["cartesian_trajectory"] >> rhs->cartesian_trajectory;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/joint_constraint.cpp
+++ b/serialization/src/ryml/moveit_msgs/joint_constraint.cpp
@@ -1,0 +1,37 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/format.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/joint_constraint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::JointConstraint const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("joint_name") << rhs.joint_name;
+    n->append_child() << yml::key("position") << freal(rhs.position);
+    n->append_child() << yml::key("tolerance_above") << freal(rhs.tolerance_above);
+    n->append_child() << yml::key("tolerance_below") << freal(rhs.tolerance_below);
+    n->append_child() << yml::key("weight") << freal(rhs.weight);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::JointConstraint* rhs)
+{
+    if (n.has_child("joint_name"))
+        n["joint_name"] >> rhs->joint_name;
+    if (n.has_child("position"))
+        n["position"] >> rhs->position;
+    if (n.has_child("tolerance_above"))
+        n["tolerance_above"] >> rhs->tolerance_above;
+    if (n.has_child("tolerance_below"))
+        n["tolerance_below"] >> rhs->tolerance_below;
+    if (n.has_child("weight"))
+        n["weight"] >> rhs->weight;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/link_padding.cpp
+++ b/serialization/src/ryml/moveit_msgs/link_padding.cpp
@@ -1,0 +1,28 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/format.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/link_padding.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::LinkPadding const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("link_name") << rhs.link_name;
+    n->append_child() << yml::key("padding") << freal(rhs.padding);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::LinkPadding* rhs)
+{
+    if (n.has_child("link_name"))
+        n["link_name"] >> rhs->link_name;
+    if (n.has_child("padding"))
+        n["padding"] >> rhs->padding;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/link_scale.cpp
+++ b/serialization/src/ryml/moveit_msgs/link_scale.cpp
@@ -1,0 +1,28 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/format.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/link_scale.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::LinkScale const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("link_name") << rhs.link_name;
+    n->append_child() << yml::key("scale") << freal(rhs.scale);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::LinkScale* rhs)
+{
+    if (n.has_child("link_name"))
+        n["link_name"] >> rhs->link_name;
+    if (n.has_child("scale"))
+        n["scale"] >> rhs->scale;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/motion_plan_request.cpp
+++ b/serialization/src/ryml/moveit_msgs/motion_plan_request.cpp
@@ -1,0 +1,72 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/moveit_msgs/workspace_parameters.h>
+#include <moveit_serialization/ryml/moveit_msgs/robot_state.h>
+#include <moveit_serialization/ryml/moveit_msgs/constraints.h>
+#include <moveit_serialization/ryml/moveit_msgs/trajectory_constraints.h>
+#include <moveit_serialization/ryml/moveit_msgs/generic_trajectory.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/motion_plan_request.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::MotionPlanRequest const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("workspace_parameters") << rhs.workspace_parameters;
+    n->append_child() << yml::key("start_state") << rhs.start_state;
+    n->append_child() << yml::key("goal_constraints") << rhs.goal_constraints;
+    n->append_child() << yml::key("path_constraints") << rhs.path_constraints;
+    n->append_child() << yml::key("trajectory_constraints") << rhs.trajectory_constraints;
+    n->append_child() << yml::key("reference_trajectories") << rhs.reference_trajectories;
+    n->append_child() << yml::key("pipeline_id") << rhs.pipeline_id;
+    n->append_child() << yml::key("planner_id") << rhs.planner_id;
+    n->append_child() << yml::key("group_name") << rhs.group_name;
+    n->append_child() << yml::key("num_planning_attempts") << rhs.num_planning_attempts;
+    n->append_child() << yml::key("allowed_planning_time") << freal(rhs.allowed_planning_time);
+    n->append_child() << yml::key("max_velocity_scaling_factor") << freal(rhs.max_velocity_scaling_factor);
+    n->append_child() << yml::key("max_acceleration_scaling_factor") << freal(rhs.max_acceleration_scaling_factor);
+    n->append_child() << yml::key("cartesian_speed_end_effector_link") << rhs.cartesian_speed_end_effector_link;
+    n->append_child() << yml::key("max_cartesian_speed") << freal(rhs.max_cartesian_speed);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::MotionPlanRequest* rhs)
+{
+    if (n.has_child("workspace_parameters"))
+        n["workspace_parameters"] >> rhs->workspace_parameters;
+    if (n.has_child("start_state"))
+        n["start_state"] >> rhs->start_state;
+    if (n.has_child("goal_constraints"))
+        n["goal_constraints"] >> rhs->goal_constraints;
+    if (n.has_child("path_constraints"))
+        n["path_constraints"] >> rhs->path_constraints;
+    if (n.has_child("trajectory_constraints"))
+        n["trajectory_constraints"] >> rhs->trajectory_constraints;
+    if (n.has_child("reference_trajectories"))
+        n["reference_trajectories"] >> rhs->reference_trajectories;
+    if (n.has_child("pipeline_id"))
+        n["pipeline_id"] >> rhs->pipeline_id;
+    if (n.has_child("planner_id"))
+        n["planner_id"] >> rhs->planner_id;
+    if (n.has_child("group_name"))
+        n["group_name"] >> rhs->group_name;
+    if (n.has_child("num_planning_attempts"))
+        n["num_planning_attempts"] >> rhs->num_planning_attempts;
+    if (n.has_child("allowed_planning_time"))
+        n["allowed_planning_time"] >> rhs->allowed_planning_time;
+    if (n.has_child("max_velocity_scaling_factor"))
+        n["max_velocity_scaling_factor"] >> rhs->max_velocity_scaling_factor;
+    if (n.has_child("max_acceleration_scaling_factor"))
+        n["max_acceleration_scaling_factor"] >> rhs->max_acceleration_scaling_factor;
+    if (n.has_child("cartesian_speed_end_effector_link"))
+        n["cartesian_speed_end_effector_link"] >> rhs->cartesian_speed_end_effector_link;
+    if (n.has_child("max_cartesian_speed"))
+        n["max_cartesian_speed"] >> rhs->max_cartesian_speed;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/object_color.cpp
+++ b/serialization/src/ryml/moveit_msgs/object_color.cpp
@@ -1,0 +1,28 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/std_msgs/color_rgba.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/object_color.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::ObjectColor const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("id") << rhs.id;
+    n->append_child() << yml::key("color") << rhs.color;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::ObjectColor* rhs)
+{
+    if (n.has_child("id"))
+        n["id"] >> rhs->id;
+    if (n.has_child("color"))
+        n["color"] >> rhs->color;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/orientation_constraint.cpp
+++ b/serialization/src/ryml/moveit_msgs/orientation_constraint.cpp
@@ -1,0 +1,48 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/geometry_msgs/quaternion.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/orientation_constraint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::OrientationConstraint const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("orientation") << rhs.orientation;
+    n->append_child() << yml::key("link_name") << rhs.link_name;
+    n->append_child() << yml::key("absolute_x_axis_tolerance") << freal(rhs.absolute_x_axis_tolerance);
+    n->append_child() << yml::key("absolute_y_axis_tolerance") << freal(rhs.absolute_y_axis_tolerance);
+    n->append_child() << yml::key("absolute_z_axis_tolerance") << freal(rhs.absolute_z_axis_tolerance);
+    n->append_child() << yml::key("parameterization") << rhs.parameterization;
+    n->append_child() << yml::key("weight") << freal(rhs.weight);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::OrientationConstraint* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("orientation"))
+        n["orientation"] >> rhs->orientation;
+    if (n.has_child("link_name"))
+        n["link_name"] >> rhs->link_name;
+    if (n.has_child("absolute_x_axis_tolerance"))
+        n["absolute_x_axis_tolerance"] >> rhs->absolute_x_axis_tolerance;
+    if (n.has_child("absolute_y_axis_tolerance"))
+        n["absolute_y_axis_tolerance"] >> rhs->absolute_y_axis_tolerance;
+    if (n.has_child("absolute_z_axis_tolerance"))
+        n["absolute_z_axis_tolerance"] >> rhs->absolute_z_axis_tolerance;
+    if (n.has_child("parameterization"))
+        n["parameterization"] >> rhs->parameterization;
+    if (n.has_child("weight"))
+        n["weight"] >> rhs->weight;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/planning_scene.cpp
+++ b/serialization/src/ryml/moveit_msgs/planning_scene.cpp
@@ -1,0 +1,58 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/geometry_msgs/transform_stamped.h>
+#include <moveit_serialization/ryml/moveit_msgs/robot_state.h>
+#include <moveit_serialization/ryml/moveit_msgs/allowed_collision_matrix.h>
+#include <moveit_serialization/ryml/moveit_msgs/link_padding.h>
+#include <moveit_serialization/ryml/moveit_msgs/link_scale.h>
+#include <moveit_serialization/ryml/moveit_msgs/object_color.h>
+#include <moveit_serialization/ryml/moveit_msgs/planning_scene_world.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/planning_scene.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::PlanningScene const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("name") << rhs.name;
+    n->append_child() << yml::key("robot_state") << rhs.robot_state;
+    n->append_child() << yml::key("robot_model_name") << rhs.robot_model_name;
+    n->append_child() << yml::key("fixed_frame_transforms") << rhs.fixed_frame_transforms;
+    n->append_child() << yml::key("allowed_collision_matrix") << rhs.allowed_collision_matrix;
+    n->append_child() << yml::key("link_padding") << rhs.link_padding;
+    n->append_child() << yml::key("link_scale") << rhs.link_scale;
+    n->append_child() << yml::key("object_colors") << rhs.object_colors;
+    n->append_child() << yml::key("world") << rhs.world;
+    n->append_child() << yml::key("is_diff") << fmt::boolalpha(rhs.is_diff);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::PlanningScene* rhs)
+{
+    if (n.has_child("name"))
+        n["name"] >> rhs->name;
+    if (n.has_child("robot_state"))
+        n["robot_state"] >> rhs->robot_state;
+    if (n.has_child("robot_model_name"))
+        n["robot_model_name"] >> rhs->robot_model_name;
+    if (n.has_child("fixed_frame_transforms"))
+        n["fixed_frame_transforms"] >> rhs->fixed_frame_transforms;
+    if (n.has_child("allowed_collision_matrix"))
+        n["allowed_collision_matrix"] >> rhs->allowed_collision_matrix;
+    if (n.has_child("link_padding"))
+        n["link_padding"] >> rhs->link_padding;
+    if (n.has_child("link_scale"))
+        n["link_scale"] >> rhs->link_scale;
+    if (n.has_child("object_colors"))
+        n["object_colors"] >> rhs->object_colors;
+    if (n.has_child("world"))
+        n["world"] >> rhs->world;
+    if (n.has_child("is_diff"))
+        n["is_diff"] >> rhs->is_diff;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/planning_scene_world.cpp
+++ b/serialization/src/ryml/moveit_msgs/planning_scene_world.cpp
@@ -1,0 +1,29 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/octomap_msgs/octomap_with_pose.h>
+#include <moveit_serialization/ryml/moveit_msgs/collision_object.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/planning_scene_world.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::PlanningSceneWorld const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("collision_objects") << rhs.collision_objects;
+    n->append_child() << yml::key("octomap") << rhs.octomap;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::PlanningSceneWorld* rhs)
+{
+    if (n.has_child("collision_objects"))
+        n["collision_objects"] >> rhs->collision_objects;
+    if (n.has_child("octomap"))
+        n["octomap"] >> rhs->octomap;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/position_constraint.cpp
+++ b/serialization/src/ryml/moveit_msgs/position_constraint.cpp
@@ -1,0 +1,40 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/geometry_msgs/vector3.h>
+#include <moveit_serialization/ryml/moveit_msgs/bounding_volume.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/position_constraint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::PositionConstraint const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("link_name") << rhs.link_name;
+    n->append_child() << yml::key("target_point_offset") << rhs.target_point_offset;
+    n->append_child() << yml::key("constraint_region") << rhs.constraint_region;
+    n->append_child() << yml::key("weight") << freal(rhs.weight);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::PositionConstraint* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("link_name"))
+        n["link_name"] >> rhs->link_name;
+    if (n.has_child("target_point_offset"))
+        n["target_point_offset"] >> rhs->target_point_offset;
+    if (n.has_child("constraint_region"))
+        n["constraint_region"] >> rhs->constraint_region;
+    if (n.has_child("weight"))
+        n["weight"] >> rhs->weight;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/robot_state.cpp
+++ b/serialization/src/ryml/moveit_msgs/robot_state.cpp
@@ -1,0 +1,36 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/sensor_msgs/joint_state.h>
+#include <moveit_serialization/ryml/sensor_msgs/multidof_joint_state.h>
+#include <moveit_serialization/ryml/moveit_msgs/attached_collision_object.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/robot_state.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::RobotState const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("joint_state") << rhs.joint_state;
+    n->append_child() << yml::key("multi_dof_joint_state") << rhs.multi_dof_joint_state;
+    n->append_child() << yml::key("attached_collision_objects") << rhs.attached_collision_objects;
+    n->append_child() << yml::key("is_diff") << fmt::boolalpha(rhs.is_diff);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::RobotState* rhs)
+{
+    if (n.has_child("joint_state"))
+        n["joint_state"] >> rhs->joint_state;
+    if (n.has_child("multi_dof_joint_state"))
+        n["multi_dof_joint_state"] >> rhs->multi_dof_joint_state;
+    if (n.has_child("attached_collision_objects"))
+        n["attached_collision_objects"] >> rhs->attached_collision_objects;
+    if (n.has_child("is_diff"))
+        n["is_diff"] >> rhs->is_diff;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/robot_trajectory.cpp
+++ b/serialization/src/ryml/moveit_msgs/robot_trajectory.cpp
@@ -1,0 +1,28 @@
+#include <moveit_serialization/ryml/trajectory_msgs/joint_trajectory.h>
+#include <moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/robot_trajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::RobotTrajectory const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("joint_trajectory") << rhs.joint_trajectory;
+    n->append_child() << yml::key("multi_dof_joint_trajectory") << rhs.multi_dof_joint_trajectory;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::RobotTrajectory* rhs)
+{
+    if (n.has_child("joint_trajectory"))
+        n["joint_trajectory"] >> rhs->joint_trajectory;
+    if (n.has_child("multi_dof_joint_trajectory"))
+        n["multi_dof_joint_trajectory"] >> rhs->multi_dof_joint_trajectory;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/trajectory_constraints.cpp
+++ b/serialization/src/ryml/moveit_msgs/trajectory_constraints.cpp
@@ -1,0 +1,25 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/moveit_msgs/constraints.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/trajectory_constraints.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::TrajectoryConstraints const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("constraints") << rhs.constraints;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::TrajectoryConstraints* rhs)
+{
+    if (n.has_child("constraints"))
+        n["constraints"] >> rhs->constraints;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/visibility_constraint.cpp
+++ b/serialization/src/ryml/moveit_msgs/visibility_constraint.cpp
@@ -1,0 +1,46 @@
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose_stamped.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/visibility_constraint.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::VisibilityConstraint const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("target_radius") << freal(rhs.target_radius);
+    n->append_child() << yml::key("target_pose") << rhs.target_pose;
+    n->append_child() << yml::key("cone_sides") << rhs.cone_sides;
+    n->append_child() << yml::key("sensor_pose") << rhs.sensor_pose;
+    n->append_child() << yml::key("max_view_angle") << freal(rhs.max_view_angle);
+    n->append_child() << yml::key("max_range_angle") << freal(rhs.max_range_angle);
+    n->append_child() << yml::key("sensor_view_direction") << rhs.sensor_view_direction;
+    n->append_child() << yml::key("weight") << freal(rhs.weight);
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::VisibilityConstraint* rhs)
+{
+    if (n.has_child("target_radius"))
+        n["target_radius"] >> rhs->target_radius;
+    if (n.has_child("target_pose"))
+        n["target_pose"] >> rhs->target_pose;
+    if (n.has_child("cone_sides"))
+        n["cone_sides"] >> rhs->cone_sides;
+    if (n.has_child("sensor_pose"))
+        n["sensor_pose"] >> rhs->sensor_pose;
+    if (n.has_child("max_view_angle"))
+        n["max_view_angle"] >> rhs->max_view_angle;
+    if (n.has_child("max_range_angle"))
+        n["max_range_angle"] >> rhs->max_range_angle;
+    if (n.has_child("sensor_view_direction"))
+        n["sensor_view_direction"] >> rhs->sensor_view_direction;
+    if (n.has_child("weight"))
+        n["weight"] >> rhs->weight;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/moveit_msgs/workspace_parameters.cpp
+++ b/serialization/src/ryml/moveit_msgs/workspace_parameters.cpp
@@ -1,0 +1,31 @@
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/geometry_msgs/vector3.h>
+
+#include <moveit_serialization/ryml/moveit_msgs/workspace_parameters.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, moveit_msgs::WorkspaceParameters const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("min_corner") << rhs.min_corner;
+    n->append_child() << yml::key("max_corner") << rhs.max_corner;
+}
+
+bool read(c4::yml::NodeRef const& n, moveit_msgs::WorkspaceParameters* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("min_corner"))
+        n["min_corner"] >> rhs->min_corner;
+    if (n.has_child("max_corner"))
+        n["max_corner"] >> rhs->max_corner;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/object_recognition_msgs/object_type.cpp
+++ b/serialization/src/ryml/object_recognition_msgs/object_type.cpp
@@ -1,0 +1,25 @@
+#include <moveit_serialization/ryml/object_recognition_msgs/object_type.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, object_recognition_msgs::ObjectType const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("key") << rhs.key;
+    n->append_child() << yml::key("db") << rhs.db;
+}
+
+bool read(c4::yml::NodeRef const& n, object_recognition_msgs::ObjectType* rhs)
+{
+    if (n.has_child("key"))
+        n["key"] >> rhs->key;
+    if (n.has_child("vertices"))
+        n["vertices"] >> rhs->db;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/octomap_msgs/octomap.cpp
+++ b/serialization/src/ryml/octomap_msgs/octomap.cpp
@@ -1,0 +1,38 @@
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+
+#include <moveit_serialization/ryml/octomap_msgs/octomap.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, octomap_msgs::Octomap const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("binary") << fmt::boolalpha(rhs.binary);
+    n->append_child() << yml::key("id") << rhs.id;
+    n->append_child() << yml::key("resolution") << freal(rhs.resolution);
+    n->append_child() << yml::key("data") << rhs.data;
+}
+
+bool read(c4::yml::NodeRef const& n, octomap_msgs::Octomap* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("binary"))
+        n["binary"] >> rhs->binary;
+    if (n.has_child("id"))
+        n["id"] >> rhs->id;
+    if (n.has_child("resolution"))
+        n["resolution"] >> rhs->resolution;
+    if (n.has_child("data"))
+        n["data"] >> rhs->data;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/octomap_msgs/octomap_with_pose.cpp
+++ b/serialization/src/ryml/octomap_msgs/octomap_with_pose.cpp
@@ -1,0 +1,32 @@
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/geometry_msgs/pose.h>
+#include <moveit_serialization/ryml/octomap_msgs/octomap.h>
+
+#include <moveit_serialization/ryml/octomap_msgs/octomap_with_pose.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, octomap_msgs::OctomapWithPose const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("origin") << rhs.origin;
+    n->append_child() << yml::key("octomap") << rhs.octomap;
+}
+
+bool read(c4::yml::NodeRef const& n, octomap_msgs::OctomapWithPose* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("origin"))
+        n["origin"] >> rhs->origin;
+    if (n.has_child("octomap"))
+        n["octomap"] >> rhs->octomap;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/ros/duration.cpp
+++ b/serialization/src/ryml/ros/duration.cpp
@@ -1,0 +1,23 @@
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/ros/duration.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, ros::Duration const& rhs)
+{
+    *n << freal(rhs.toSec());
+}
+
+bool read(c4::yml::NodeRef const& n, ros::Duration* rhs)
+{
+    double secs{ 0.0 };
+    n >> secs;
+
+    rhs->fromSec(secs);
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/ros/time.cpp
+++ b/serialization/src/ryml/ros/time.cpp
@@ -1,0 +1,23 @@
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/ros/time.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, ros::Time const& rhs)
+{
+    *n << freal(rhs.toSec());
+}
+
+bool read(c4::yml::NodeRef const& n, ros::Time* rhs)
+{
+    double secs{ 0.0 };
+    n >> secs;
+
+    rhs->fromSec(secs);
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/sensor_msgs/joint_state.cpp
+++ b/serialization/src/ryml/sensor_msgs/joint_state.cpp
@@ -1,0 +1,36 @@
+#include <moveit_serialization/ryml/std.h>
+
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/sensor_msgs/joint_state.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, sensor_msgs::JointState const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("name") << rhs.name;
+    n->append_child() << yml::key("position") << rhs.position;
+    n->append_child() << yml::key("velocity") << rhs.velocity;
+    n->append_child() << yml::key("effort") << rhs.effort;
+}
+
+bool read(c4::yml::NodeRef const& n, sensor_msgs::JointState* rhs)
+{
+    n["header"] >> rhs->header;
+    n["name"] >> rhs->name;
+
+    if (n.has_child("position"))
+        n["position"] >> rhs->position;
+    if (n.has_child("velocity"))
+        n["velocity"] >> rhs->velocity;
+    if (n.has_child("effort"))
+        n["effort"] >> rhs->effort;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/sensor_msgs/multidof_joint_state.cpp
+++ b/serialization/src/ryml/sensor_msgs/multidof_joint_state.cpp
@@ -1,0 +1,39 @@
+#include <moveit_serialization/ryml/std.h>
+
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/geometry_msgs/transform.h>
+#include <moveit_serialization/ryml/geometry_msgs/twist.h>
+#include <moveit_serialization/ryml/geometry_msgs/wrench.h>
+#include <moveit_serialization/ryml/sensor_msgs/multidof_joint_state.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, sensor_msgs::MultiDOFJointState const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("joint_names") << rhs.joint_names;
+    n->append_child() << yml::key("transforms") << rhs.transforms;
+    n->append_child() << yml::key("twist") << rhs.twist;
+    n->append_child() << yml::key("wrench") << rhs.wrench;
+}
+
+bool read(c4::yml::NodeRef const& n, sensor_msgs::MultiDOFJointState* rhs)
+{
+    n["header"] >> rhs->header;
+    n["joint_names"] >> rhs->joint_names;
+
+    if (n.has_child("transforms"))
+        n["transforms"] >> rhs->transforms;
+    if (n.has_child("twist"))
+        n["twist"] >> rhs->twist;
+    if (n.has_child("wrench"))
+        n["wrench"] >> rhs->wrench;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/shape_msgs/mesh.cpp
+++ b/serialization/src/ryml/shape_msgs/mesh.cpp
@@ -1,0 +1,29 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/geometry_msgs/point.h>
+#include <moveit_serialization/ryml/shape_msgs/mesh_triangle.h>
+
+#include <moveit_serialization/ryml/shape_msgs/mesh.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, shape_msgs::Mesh const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("triangles") << rhs.triangles;
+    n->append_child() << yml::key("vertices") << rhs.vertices;
+}
+
+bool read(c4::yml::NodeRef const& n, shape_msgs::Mesh* rhs)
+{
+    if (n.has_child("triangles"))
+        n["triangles"] >> rhs->triangles;
+    if (n.has_child("vertices"))
+        n["vertices"] >> rhs->triangles;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/shape_msgs/mesh_triangle.cpp
+++ b/serialization/src/ryml/shape_msgs/mesh_triangle.cpp
@@ -1,0 +1,24 @@
+#include <moveit_serialization/ryml/shape_msgs/mesh_triangle.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, shape_msgs::MeshTriangle const& rhs)
+{
+    *n |= c4::yml::SEQ;
+
+    for (auto const& v : rhs.vertex_indices)
+        n->append_child() << v;
+}
+
+bool read(c4::yml::NodeRef const& n, shape_msgs::MeshTriangle* rhs)
+{
+    n[0] >> rhs->vertex_indices[0];
+    n[1] >> rhs->vertex_indices[1];
+    n[2] >> rhs->vertex_indices[2];
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/shape_msgs/plane.cpp
+++ b/serialization/src/ryml/shape_msgs/plane.cpp
@@ -1,0 +1,29 @@
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/shape_msgs/plane.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, shape_msgs::Plane const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child({ yml::KEYSEQ, "coef" });
+    auto c = n->last_child();
+
+    for (auto const& val : rhs.coef)
+        c.append_child() << freal(val);
+}
+
+bool read(c4::yml::NodeRef const& n, shape_msgs::Plane* rhs)
+{
+    n["coef"][0] >> rhs->coef[0];
+    n["coef"][1] >> rhs->coef[1];
+    n["coef"][2] >> rhs->coef[2];
+    n["coef"][3] >> rhs->coef[3];
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/shape_msgs/solid_primitive.cpp
+++ b/serialization/src/ryml/shape_msgs/solid_primitive.cpp
@@ -1,0 +1,24 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/shape_msgs/solid_primitive.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, shape_msgs::SolidPrimitive const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("type") << rhs.type;
+    n->append_child() << yml::key("dimensions") << rhs.dimensions;
+}
+
+bool read(c4::yml::NodeRef const& n, shape_msgs::SolidPrimitive* rhs)
+{
+    n["type"] >> rhs->type;
+    n["dimensions"] >> rhs->dimensions;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/std_msgs/color_rgba.cpp
+++ b/serialization/src/ryml/std_msgs/color_rgba.cpp
@@ -1,0 +1,28 @@
+#include <moveit_serialization/ryml/format.h>
+#include <moveit_serialization/ryml/std_msgs/color_rgba.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, std_msgs::ColorRGBA const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("r") << freal(rhs.r);
+    n->append_child() << yml::key("g") << freal(rhs.g);
+    n->append_child() << yml::key("b") << freal(rhs.b);
+    n->append_child() << yml::key("a") << freal(rhs.a);
+}
+
+bool read(c4::yml::NodeRef const& n, std_msgs::ColorRGBA* rhs)
+{
+    n["r"] >> rhs->r;
+    n["g"] >> rhs->g;
+    n["b"] >> rhs->b;
+    n["a"] >> rhs->a;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/std_msgs/header.cpp
+++ b/serialization/src/ryml/std_msgs/header.cpp
@@ -1,0 +1,36 @@
+#include <moveit_serialization/ryml/std.h>
+
+#include <moveit_serialization/ryml/std_msgs/header.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, std_msgs::Header const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child({ yml::KEYMAP, "stamp" });
+    auto c = n->last_child();
+    c.append_child() << yml::key("sec") << rhs.stamp.sec;
+    c.append_child() << yml::key("nsec") << rhs.stamp.nsec;
+
+    n->append_child() << yml::key("seq") << rhs.seq;
+    n->append_child() << yml::key("frame_id") << rhs.frame_id;
+}
+
+bool read(c4::yml::NodeRef const& n, std_msgs::Header* rhs)
+{
+    n["frame_id"] >> rhs->frame_id;
+
+    if (n.has_child("seq"))
+        n["seq"] >> rhs->seq;
+    if (n.has_child("stamp")) {
+        n["stamp"]["sec"] >> rhs->stamp.sec;
+        n["stamp"]["nsec"] >> rhs->stamp.nsec;
+    }
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/trajectory_msgs/joint_trajectory.cpp
+++ b/serialization/src/ryml/trajectory_msgs/joint_trajectory.cpp
@@ -1,0 +1,32 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/trajectory_msgs/joint_trajectory_point.h>
+
+#include <moveit_serialization/ryml/trajectory_msgs/joint_trajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, trajectory_msgs::JointTrajectory const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("joint_names") << rhs.joint_names;
+    n->append_child() << yml::key("points") << rhs.points;
+}
+
+bool read(c4::yml::NodeRef const& n, trajectory_msgs::JointTrajectory* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("joint_names"))
+        n["joint_names"] >> rhs->joint_names;
+    if (n.has_child("points"))
+        n["points"] >> rhs->points;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/trajectory_msgs/joint_trajectory_point.cpp
+++ b/serialization/src/ryml/trajectory_msgs/joint_trajectory_point.cpp
@@ -1,0 +1,37 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/ros/duration.h>
+
+#include <moveit_serialization/ryml/trajectory_msgs/joint_trajectory_point.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, trajectory_msgs::JointTrajectoryPoint const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("positions") << rhs.positions;
+    n->append_child() << yml::key("velocities") << rhs.velocities;
+    n->append_child() << yml::key("accelerations") << rhs.accelerations;
+    n->append_child() << yml::key("effort") << rhs.effort;
+    n->append_child() << yml::key("time_from_start") << rhs.time_from_start;
+}
+
+bool read(c4::yml::NodeRef const& n, trajectory_msgs::JointTrajectoryPoint* rhs)
+{
+    if (n.has_child("positions"))
+        n["positions"] >> rhs->positions;
+    if (n.has_child("velocities"))
+        n["velocities"] >> rhs->velocities;
+    if (n.has_child("accelerations"))
+        n["accelerations"] >> rhs->accelerations;
+    if (n.has_child("effort"))
+        n["effort"] >> rhs->effort;
+    if (n.has_child("time_from_start"))
+        n["time_from_start"] >> rhs->time_from_start;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/trajectory_msgs/multidof_joint_trajectory.cpp
+++ b/serialization/src/ryml/trajectory_msgs/multidof_joint_trajectory.cpp
@@ -1,0 +1,32 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/std_msgs/header.h>
+#include <moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory_point.h>
+
+#include <moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, trajectory_msgs::MultiDOFJointTrajectory const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("header") << rhs.header;
+    n->append_child() << yml::key("joint_names") << rhs.joint_names;
+    n->append_child() << yml::key("points") << rhs.points;
+}
+
+bool read(c4::yml::NodeRef const& n, trajectory_msgs::MultiDOFJointTrajectory* rhs)
+{
+    if (n.has_child("header"))
+        n["header"] >> rhs->header;
+    if (n.has_child("joint_names"))
+        n["joint_names"] >> rhs->joint_names;
+    if (n.has_child("points"))
+        n["points"] >> rhs->points;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4

--- a/serialization/src/ryml/trajectory_msgs/multidof_joint_trajectory_point.cpp
+++ b/serialization/src/ryml/trajectory_msgs/multidof_joint_trajectory_point.cpp
@@ -1,0 +1,36 @@
+#include <moveit_serialization/ryml/std.h>
+#include <moveit_serialization/ryml/geometry_msgs/transform.h>
+#include <moveit_serialization/ryml/geometry_msgs/twist.h>
+#include <moveit_serialization/ryml/ros/duration.h>
+
+#include <moveit_serialization/ryml/trajectory_msgs/multidof_joint_trajectory_point.h>
+
+namespace c4 {
+namespace yml {
+
+void write(c4::yml::NodeRef* n, trajectory_msgs::MultiDOFJointTrajectoryPoint const& rhs)
+{
+    *n |= c4::yml::MAP;
+
+    n->append_child() << yml::key("transforms") << rhs.transforms;
+    n->append_child() << yml::key("velocities") << rhs.velocities;
+    n->append_child() << yml::key("accelerations") << rhs.accelerations;
+    n->append_child() << yml::key("time_from_start") << rhs.time_from_start;
+}
+
+bool read(c4::yml::NodeRef const& n, trajectory_msgs::MultiDOFJointTrajectoryPoint* rhs)
+{
+    if (n.has_child("transforms"))
+        n["transforms"] >> rhs->transforms;
+    if (n.has_child("velocities"))
+        n["velocities"] >> rhs->velocities;
+    if (n.has_child("accelerations"))
+        n["accelerations"] >> rhs->accelerations;
+    if (n.has_child("time_from_start"))
+        n["time_from_start"] >> rhs->time_from_start;
+
+    return true;
+}
+
+}  // namespace yml
+}  // namespace c4


### PR DESCRIPTION
Rapidyaml is one the fastest YAML parser and emitter available. It is tested extensively and against a yaml test-suite.